### PR TITLE
Add alias to set a Issue's or Pull Request's Milestone

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Cake.GitHub
 
-Add-in for Cake that allows integration with GitHub. The following integrations are support:
+Add-in for Cake that allows integration with GitHub. The following integrations are supported:
 
-* Status
-* Create Release
- 
+* [Status](#status)
+* [Create Release](#create-release)
+* [Set Milestone](#set-milestone)
+
 ## Status
 
 Allows updating the status of a build in GitHub.
@@ -68,6 +69,50 @@ Task("CreateGitHubRelease")
             Overwrite = false
         }
     );
-    
+
+});
+```
+
+## Set Milestone
+
+Assigns a Issue of Pull Request to a [Milestone](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/about-milestones).
+
+API documentation: https://docs.github.com/en/rest/issues/issues#update-an-issue
+
+```cs
+Task("SetMilestone")
+.Does(async () =>
+{
+    await GitHubSetMilestoneAsync(
+        // The user name to use for authentication (pass null when using an access token).
+        userName: "user",
+
+        // The access token or password to use for authentication.
+        apiToken: "apitoken",
+
+        // The owner (user or group) of the repository.
+        owner: "owner",
+
+        // The name of the repository.
+        repository: "repository",
+
+        // The number of the issue or pull request to set the milestone for.
+        number: 23,
+
+        // The title of the milestone to assign the issue or pull request to.
+        // Note that GitHub treats milestone titles *case-sensitive*.
+        milestoneTitle: "Milestone 1",
+
+        // Specify additional settings for updating the milestone (optional)
+        settings: GitHubSetMilestoneSettings()
+        {
+            // Set to true to set the issue's or pull request's milestone even if it is already set to a different milestone (default: false)
+            Overwrite = false,
+
+            // Set to true to create a milestone with the specified title if no such milestone exists (default: false)
+            // When set to false, GitHubSetMilestoneAsync() will fail if no matching milestone is found.
+            CreateMilestone = false
+        }
+    );
 });
 ```

--- a/src/Cake.GitHub.Tests/Helpers/GitHubClientMock.cs
+++ b/src/Cake.GitHub.Tests/Helpers/GitHubClientMock.cs
@@ -38,6 +38,23 @@ namespace Cake.GitHub.Tests
             }
         }
 
+        public class IssuesClientMock
+        {
+            public Mock<IIssuesClient> Mock { get; }
+
+            public IIssuesClient Object => Mock.Object;
+
+            public Mock<IMilestonesClient> Milestone { get; } = new Mock<IMilestonesClient>(MockBehavior.Strict);
+
+
+            public IssuesClientMock()
+            {
+                Mock = new Mock<IIssuesClient>(MockBehavior.Strict);
+
+                Mock.Setup(x => x.Milestone).Returns(Milestone.Object);
+            }
+        }
+
         private readonly Mock<IGitHubClient> _mock = new Mock<IGitHubClient>(MockBehavior.Strict);
 
 
@@ -48,11 +65,14 @@ namespace Cake.GitHub.Tests
 
         public GitDatabaseClientMock Git { get; } = new GitDatabaseClientMock();
 
+        public IssuesClientMock Issues { get; } = new IssuesClientMock();
+
 
         public GitHubClientMock()
         {
             _mock.Setup(x => x.Repository).Returns(Repository.Object);
             _mock.Setup(x => x.Git).Returns(Git.Object);
+            _mock.Setup(x => x.Issue).Returns(Issues.Object);
         }
     }
 }

--- a/src/Cake.GitHub.Tests/Helpers/MoqExtensions.cs
+++ b/src/Cake.GitHub.Tests/Helpers/MoqExtensions.cs
@@ -19,5 +19,12 @@ namespace Cake.GitHub.Tests
 
         public static IReturnsResult<TMock> ReturnsCompletedTask<TMock>(this IReturns<TMock, Task> mock) where TMock : class =>
             mock.Returns(Task.CompletedTask);
+
+        public static IReturnsResult<IIssuesClient> SetupUpdate(this Mock<IIssuesClient> mock) =>
+            mock.Setup(x => x.Update(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<IssueUpdate>()))
+                .ReturnsAsync((string owner, string repo, int number, IssueUpdate update) => new TestIssue() { Number = number });
+
+        public static IReturnsResult<IMilestonesClient> ReturnsMilestonesAsync(this IReturns<IMilestonesClient, Task<IReadOnlyList<Milestone>>> mock, params Milestone[] milestones) =>
+            mock.ReturnsAsync(milestones);
     }
 }

--- a/src/Cake.GitHub.Tests/Helpers/MoqExtensions.cs
+++ b/src/Cake.GitHub.Tests/Helpers/MoqExtensions.cs
@@ -26,5 +26,8 @@ namespace Cake.GitHub.Tests
 
         public static IReturnsResult<IMilestonesClient> ReturnsMilestonesAsync(this IReturns<IMilestonesClient, Task<IReadOnlyList<Milestone>>> mock, params Milestone[] milestones) =>
             mock.ReturnsAsync(milestones);
+
+        public static IReturnsResult<IMilestonesClient> ReturnsEmptyListAsync(this IReturns<IMilestonesClient, Task<IReadOnlyList<Milestone>>> mock) =>
+            mock.ReturnsAsync(Array.Empty<Milestone>());
     }
 }

--- a/src/Cake.GitHub.Tests/Helpers/TestIssue.cs
+++ b/src/Cake.GitHub.Tests/Helpers/TestIssue.cs
@@ -1,0 +1,19 @@
+﻿using Octokit;
+
+namespace Cake.GitHub.Tests
+{
+    internal class TestIssue : Issue
+    {
+        public new int Number
+        {
+            get => base.Number;
+            set => base.Number = value;
+        }
+
+        public new Milestone Milestone
+        {
+            get => base.Milestone;
+            set => base.Milestone = value;
+        }
+    }
+}

--- a/src/Cake.GitHub.Tests/Helpers/TestMilestone.cs
+++ b/src/Cake.GitHub.Tests/Helpers/TestMilestone.cs
@@ -1,0 +1,19 @@
+﻿using Octokit;
+
+namespace Cake.GitHub.Tests
+{
+    internal class TestMilestone : Milestone
+    {
+        public new int Number
+        {
+            get => base.Number;
+            set => base.Number = value;
+        }
+
+        public new string Title
+        {
+            get => base.Title;
+            set => base.Title = value;
+        }
+    }
+}

--- a/src/Cake.GitHub.Tests/Issues/GitHubCreateReleaseSettingsTests.cs
+++ b/src/Cake.GitHub.Tests/Issues/GitHubCreateReleaseSettingsTests.cs
@@ -1,0 +1,23 @@
+﻿using Xunit;
+
+namespace Cake.GitHub.Tests
+{
+    /// <summary>
+    /// Tests for <see cref="GitHubSetMilestoneSettings"/>
+    /// </summary>
+    public class GitHubSetMilestoneSettingsTests
+    {
+
+        [Fact]
+        public void Properties_have_expected_default_values()
+        {
+            // ARRANGE
+            var sut = new GitHubSetMilestoneSettings();
+
+            // ACT
+
+            // ASSERT
+            Assert.False(sut.Overwrite);
+        }
+    }
+}

--- a/src/Cake.GitHub.Tests/Issues/GitHubCreateReleaseSettingsTests.cs
+++ b/src/Cake.GitHub.Tests/Issues/GitHubCreateReleaseSettingsTests.cs
@@ -7,7 +7,6 @@ namespace Cake.GitHub.Tests
     /// </summary>
     public class GitHubSetMilestoneSettingsTests
     {
-
         [Fact]
         public void Properties_have_expected_default_values()
         {
@@ -18,6 +17,7 @@ namespace Cake.GitHub.Tests
 
             // ASSERT
             Assert.False(sut.Overwrite);
+            Assert.False(sut.CreateMilestone);
         }
     }
 }

--- a/src/Cake.GitHub.Tests/Issues/GitHubIssueUpdaterTests.cs
+++ b/src/Cake.GitHub.Tests/Issues/GitHubIssueUpdaterTests.cs
@@ -1,0 +1,257 @@
+﻿using Moq;
+using Octokit;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Cake.GitHub.Tests
+{
+    /// <summary>
+    /// Tests for <see cref="GitHubIssueUpdater"/>
+    /// </summary>
+    public class GitHubIssueUpdaterTests
+    {
+        private readonly XunitCakeLog _testLog;
+        private readonly GitHubClientMock _clientMock;
+
+
+        public GitHubIssueUpdaterTests(ITestOutputHelper testOutputHelper)
+        {
+            _testLog = new XunitCakeLog(testOutputHelper);
+            _clientMock = new GitHubClientMock();
+        }
+
+
+        [Theory]
+        [InlineData(null, "repo", "milestone", "owner")]
+        [InlineData("", "repo", "milestone", "owner")]
+        [InlineData(" ", "repo", "milestone", "owner")]
+        [InlineData("\t", "repo", "milestone", "owner")]
+        [InlineData("owner", null, "milestone", "repository")]
+        [InlineData("owner", "", "milestone", "repository")]
+        [InlineData("owner", " ", "milestone", "repository")]
+        [InlineData("owner", "\t", "milestone", "repository")]
+        [InlineData("owner", "repo", null, "milestoneTitle")]
+        [InlineData("owner", "repo", "", "milestoneTitle")]
+        [InlineData("owner", "repo", " ", "milestoneTitle")]
+        [InlineData("owner", "repo", "\t", "milestoneTitle")]
+        public async Task SetMilestoneAsync_checks_string_parameters_for_null_or_whitespace(string owner, string repo, string milestoneTitle, string expectedParameterName)
+        {
+            // ARRANGE
+            var sut = new GitHubIssueUpdater(_testLog, _clientMock.Object);
+
+            // ACT 
+            var ex = await Record.ExceptionAsync(async () => await sut.SetMilestoneAsync(owner: owner, repository: repo, number: 23, milestoneTitle: milestoneTitle, new GitHubSetMilestoneSettings()));
+
+            // ASSERT
+            var argumentNullException = Assert.IsType<ArgumentException>(ex);
+            Assert.Equal(expectedParameterName, argumentNullException.ParamName);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-23)]
+        public async Task SetMilestoneAsync_checks_issue_or_pr_number(int number)
+        {
+            // ARRANGE
+            var sut = new GitHubIssueUpdater(_testLog, _clientMock.Object);
+
+            // ACT 
+            var ex = await Record.ExceptionAsync(async () => await sut.SetMilestoneAsync(owner: "owner", repository: "repo", number: number, milestoneTitle: "milestone", new GitHubSetMilestoneSettings()));
+
+            // ASSERT
+            var argumentNullException = Assert.IsType<ArgumentOutOfRangeException>(ex);
+            Assert.Equal("number", argumentNullException.ParamName);
+        }
+
+        [Fact]
+        public async Task SetMilestoneAsync_throws_IssueNotFoundException_if_issue_does_not_exist()
+        {
+            // ARRANGE
+            var owner = "owner";
+            var repo = "repo";
+            var number = 23;
+            var sut = new GitHubIssueUpdater(_testLog, _clientMock.Object);
+
+            _clientMock.Issues.Mock
+                .Setup(x => x.Get(owner, repo, number))
+                .ThrowsNotFoundAsync();
+
+            // ACT 
+            var ex = await Record.ExceptionAsync(async () => await sut.SetMilestoneAsync(owner: owner, repository: repo, number: number, milestoneTitle: "milestone", new GitHubSetMilestoneSettings()));
+
+            // ASSERT
+            Assert.IsType<IssueNotFoundException>(ex);
+        }
+
+        [Fact]
+        public async Task SetMilestoneAsync_throws_MilestoneNotFoundException_if_milestone_does_not_exist()
+        {
+            // ARRANGE
+            var owner = "owner";
+            var repo = "repo";
+            var number = 23;
+            var sut = new GitHubIssueUpdater(_testLog, _clientMock.Object);
+
+            _clientMock.Issues.Mock
+                .Setup(x => x.Get(owner, repo, number))
+                .ReturnsAsync(new TestIssue() { Number = number });
+
+            _clientMock.Issues.Milestone
+                .Setup(x => x.GetAllForRepository(owner, repo, It.IsAny<MilestoneRequest>()))
+                .ReturnsMilestonesAsync(
+                    new TestMilestone() { Number = 1, Title = "Milestone 1" },
+                    new TestMilestone() { Number = 1, Title = "Milestone 2" }
+                );
+
+            // ACT 
+            var ex = await Record.ExceptionAsync(async () => await sut.SetMilestoneAsync(owner: owner, repository: repo, number: number, milestoneTitle: "milestone", new GitHubSetMilestoneSettings()));
+
+            // ASSERT
+            Assert.IsType<MilestoneNotFoundException>(ex);
+            _clientMock.Issues.Milestone.Verify(x => x.GetAllForRepository(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<MilestoneRequest>()), Times.Once);
+
+            // When requesting milestones, request both open and closes milestones
+            _clientMock.Issues.Milestone.Verify(x => x.GetAllForRepository(owner, repo, It.Is<MilestoneRequest>(x => x.State == ItemStateFilter.All)), Times.Once);
+        }
+
+        [Theory]
+        [InlineData("Milestone 1", "Milestone 1", true)]
+        [InlineData("milestone 1", "milestone 1", true)]
+        [InlineData("Milestone 1", "milestone 1", false)]
+        [InlineData("milestone 1", "Milestone 1", false)]
+        public async Task SetMilestoneAsync_uses_case_insensitive_comparison_for_milestone_titles(string existingMilestoneTitle, string requestedMilestoneTitle, bool expectMatch)
+        {
+            // ARRANGE
+            var owner = "owner";
+            var repo = "repo";
+            var number = 23;
+            var sut = new GitHubIssueUpdater(_testLog, _clientMock.Object);
+
+            _clientMock.Issues.Mock
+                .Setup(x => x.Get(owner, repo, number))
+                .ReturnsAsync(new TestIssue() { Number = number });
+
+            _clientMock.Issues.Mock.SetupUpdate();
+
+            _clientMock.Issues.Milestone
+                .Setup(x => x.GetAllForRepository(owner, repo, It.IsAny<MilestoneRequest>()))
+                .ReturnsMilestonesAsync(
+                    new TestMilestone() { Number = 1, Title = existingMilestoneTitle }
+                );
+
+            // ACT 
+            var ex = await Record.ExceptionAsync(async () => await sut.SetMilestoneAsync(owner: owner, repository: repo, number: number, milestoneTitle: requestedMilestoneTitle, new GitHubSetMilestoneSettings()));
+
+            // ASSERT
+            if (expectMatch)
+            {
+                Assert.Null(ex);
+            }
+            else
+            {
+                Assert.IsType<MilestoneNotFoundException>(ex);
+            }
+        }
+
+        [Fact]
+        public async Task SetMilestoneAsync_sets_the_milestone_to_the_expected_value()
+        {
+            // ARRANGE
+            var owner = "owner";
+            var repo = "repo";
+            var issueNumber = 23;
+            var milestoneTitle = "Milestone 1";
+            var milestoneNumber = 42;
+            var sut = new GitHubIssueUpdater(_testLog, _clientMock.Object);
+
+            _clientMock.Issues.Mock
+                .Setup(x => x.Get(owner, repo, issueNumber))
+                .ReturnsAsync(new TestIssue() { Number = issueNumber });
+
+            _clientMock.Issues.Milestone
+                .Setup(x => x.GetAllForRepository(owner, repo, It.IsAny<MilestoneRequest>()))
+                .ReturnsMilestonesAsync(
+                    new TestMilestone() { Number = milestoneNumber, Title = milestoneTitle }
+                );
+
+            _clientMock.Issues.Mock.SetupUpdate();
+
+            // ACT 
+            await sut.SetMilestoneAsync(owner: owner, repository: repo, number: issueNumber, milestoneTitle: milestoneTitle, new GitHubSetMilestoneSettings());
+
+            // ASSERT
+            _clientMock.Issues.Mock.Verify(x => x.Update(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<IssueUpdate>()), Times.Once);
+            _clientMock.Issues.Mock.Verify(x => x.Update(owner, repo, issueNumber, It.Is<IssueUpdate>(x => x.Milestone == milestoneNumber)), Times.Once);
+        }
+
+        [Fact]
+        public async Task SetMilestoneAsync_throws_MilestoneAlreadySetException_when_the_issues_milestone_is_already_set()
+        {
+            // ARRANGE
+            var owner = "owner";
+            var repo = "repo";
+            var issueNumber = 23;
+            var sut = new GitHubIssueUpdater(_testLog, _clientMock.Object);
+
+            _clientMock.Issues.Mock
+                .Setup(x => x.Get(owner, repo, issueNumber))
+                .ReturnsAsync(
+                    new TestIssue()
+                    {
+                        Number = issueNumber,
+                        Milestone = new TestMilestone() { Number = 1, Title = "Milestone 1" }
+                    });
+
+            _clientMock.Issues.Milestone
+                .Setup(x => x.GetAllForRepository(owner, repo, It.IsAny<MilestoneRequest>()))
+                .ReturnsMilestonesAsync(
+                    new TestMilestone() { Number = 1, Title = "Milestone 1" },
+                    new TestMilestone() { Number = 2, Title = "Milestone 2" }
+                );
+
+            _clientMock.Issues.Mock.SetupUpdate();
+
+            // ACT 
+            var ex = await Record.ExceptionAsync(async () => await sut.SetMilestoneAsync(owner: owner, repository: repo, number: issueNumber, milestoneTitle: "Milestone 2", new GitHubSetMilestoneSettings()));
+
+            // ASSERT
+            Assert.IsType<MilestoneAlreadySetException>(ex);
+            _clientMock.Issues.Mock.Verify(x => x.Update(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<IssueUpdate>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task SetMilestoneAsync_performs_no_update_if_milestone_is_already_set_to_expected_value()
+        {
+            // ARRANGE
+            var owner = "owner";
+            var repo = "repo";
+            var issueNumber = 23;
+            var milestoneTitle = "Milestone 1";
+            var milestoneNumber = 42;
+            var sut = new GitHubIssueUpdater(_testLog, _clientMock.Object);
+
+            _clientMock.Issues.Mock
+                .Setup(x => x.Get(owner, repo, issueNumber))
+                .ReturnsAsync(
+                    new TestIssue()
+                    {
+                        Number = issueNumber,
+                        Milestone = new TestMilestone() { Number = milestoneNumber }
+                    });
+
+            _clientMock.Issues.Milestone
+                .Setup(x => x.GetAllForRepository(owner, repo, It.IsAny<MilestoneRequest>()))
+                .ReturnsMilestonesAsync(
+                    new TestMilestone() { Number = milestoneNumber, Title = milestoneTitle }
+                );
+
+            // ACT 
+            await sut.SetMilestoneAsync(owner: owner, repository: repo, number: issueNumber, milestoneTitle: milestoneTitle, new GitHubSetMilestoneSettings());
+
+            // ASSERT
+            _clientMock.Issues.Mock.Verify(x => x.Update(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<IssueUpdate>()), Times.Never);
+        }
+    }
+}

--- a/src/Cake.GitHub/GitHubAppAliases.Issues.cs
+++ b/src/Cake.GitHub/GitHubAppAliases.Issues.cs
@@ -8,8 +8,20 @@ namespace Cake.GitHub
     [CakeAliasCategory("GitHub")]
     public static partial class GitHubAliases
     {
-        //TODO: Allow specifxing milestone number instead of milestone name
-
+        /// <summary>
+        /// Sets the Milestone for an Issue or Pull Request.
+        /// </summary>
+        /// <param name="context">The Cake context.</param>
+        /// <param name="userName">The user name to use for authentication (pass <c>null</c> when using an access token).</param>
+        /// <param name="apiToken">The access token or password to use for authentication.</param>
+        /// <param name="owner">The owner (user or group) of the repository.</param>
+        /// <param name="repository">The name of the repository.</param>
+        /// <param name="number">The number of the Issue or Pull Request to set the Milestone for.</param>
+        /// <param name="milestoneTitle">
+        /// The title of the milestone to assign the Issue or Pull Request to.
+        /// Note that GitHub treats Milestone titles case-sensitive.
+        /// </param>
+        /// <param name="settings">Additional settings for updating the Milestone (optional).</param>
         [CakeMethodAlias]
         public static async Task GitHubSetMilestoneAsync(
             this ICakeContext context,

--- a/src/Cake.GitHub/GitHubAppAliases.Issues.cs
+++ b/src/Cake.GitHub/GitHubAppAliases.Issues.cs
@@ -1,0 +1,39 @@
+﻿using Cake.Core;
+using Cake.Core.Annotations;
+using Octokit;
+using System.Threading.Tasks;
+
+namespace Cake.GitHub
+{
+    [CakeAliasCategory("GitHub")]
+    public static partial class GitHubAliases
+    {
+        //TODO: Allow specifxing milestone number instead of milestone name
+
+        [CakeMethodAlias]
+        public static async Task GitHubSetMilestoneAsync(
+            this ICakeContext context,
+            string? userName,
+            string apiToken,
+            string owner,
+            string repository,
+            int number,
+            string milestoneTitle,
+            GitHubSetMilestoneSettings? settings = null)
+        {
+            settings = settings ?? new GitHubSetMilestoneSettings();
+
+            var connection = CreateConnection(userName, apiToken);
+            var githubClient = new GitHubClient(connection);
+            var issueUpdater = new GitHubIssueUpdater(context.Log, githubClient);
+
+            await issueUpdater.SetMilestoneAsync(
+                owner: owner,
+                repository: repository,
+                number: number,
+                milestoneTitle: milestoneTitle,
+                settings: settings
+            );
+        }
+    }
+}

--- a/src/Cake.GitHub/Issues/Exceptions/GitHubIssueException.cs
+++ b/src/Cake.GitHub/Issues/Exceptions/GitHubIssueException.cs
@@ -2,11 +2,20 @@
 
 namespace Cake.GitHub
 {
+    /// <summary>
+    /// Base class for exceptions that can be thrown while updating GitHub Issues (or Pull Requests)
+    /// </summary>
     public abstract class GitHubIssueException : Exception
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GitHubIssueException"/> class with the specified error message.
+        /// </summary>
         protected GitHubIssueException(string message) : base(message)
         { }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GitHubIssueException"/> class with the specified error message and inner exception.
+        /// </summary>
         protected GitHubIssueException(string message, Exception innerException) : base(message, innerException)
         { }
     }

--- a/src/Cake.GitHub/Issues/Exceptions/GitHubIssueException.cs
+++ b/src/Cake.GitHub/Issues/Exceptions/GitHubIssueException.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Cake.GitHub
+{
+    public abstract class GitHubIssueException : Exception
+    {
+        protected GitHubIssueException(string message) : base(message)
+        { }
+
+        protected GitHubIssueException(string message, Exception innerException) : base(message, innerException)
+        { }
+    }
+}

--- a/src/Cake.GitHub/Issues/Exceptions/IssueNotFoundException.cs
+++ b/src/Cake.GitHub/Issues/Exceptions/IssueNotFoundException.cs
@@ -2,11 +2,14 @@
 
 namespace Cake.GitHub
 {
-    internal class IssueNotFoundException : GitHubIssueException
+    /// <summary>
+    /// Thrown when an Issue or Pull Request was not found.
+    /// </summary>
+    public sealed class IssueNotFoundException : GitHubIssueException
     {
-        public IssueNotFoundException(string message) : base(message)
-        { }
-
+        /// <summary>
+        /// Initializes a new instance of <see cref="IssueNotFoundException"/> with the specified error message and inner exception.
+        /// </summary>
         public IssueNotFoundException(string message, Exception innerException) : base(message, innerException)
         { }
     }

--- a/src/Cake.GitHub/Issues/Exceptions/IssueNotFoundException.cs
+++ b/src/Cake.GitHub/Issues/Exceptions/IssueNotFoundException.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Cake.GitHub
+{
+    internal class IssueNotFoundException : GitHubIssueException
+    {
+        public IssueNotFoundException(string message) : base(message)
+        { }
+
+        public IssueNotFoundException(string message, Exception innerException) : base(message, innerException)
+        { }
+    }
+}

--- a/src/Cake.GitHub/Issues/Exceptions/MilestoneAlreadySetException.cs
+++ b/src/Cake.GitHub/Issues/Exceptions/MilestoneAlreadySetException.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Cake.GitHub
+{
+    internal class MilestoneAlreadySetException : GitHubIssueException
+    {
+        public MilestoneAlreadySetException(string message) : base(message)
+        { }
+
+        public MilestoneAlreadySetException(string message, Exception innerException) : base(message, innerException)
+        { }
+    }
+}

--- a/src/Cake.GitHub/Issues/Exceptions/MilestoneAlreadySetException.cs
+++ b/src/Cake.GitHub/Issues/Exceptions/MilestoneAlreadySetException.cs
@@ -2,12 +2,15 @@
 
 namespace Cake.GitHub
 {
-    internal class MilestoneAlreadySetException : GitHubIssueException
+    /// <summary>
+    /// Thrown when an Issue's or Pull Request's Milestone is already set.
+    /// </summary>
+    public sealed class MilestoneAlreadySetException : GitHubIssueException
     {
+        /// <summary>
+        /// Initializes a new instance of <see cref="MilestoneAlreadySetException"/> with the specified error message.
+        /// </summary>
         public MilestoneAlreadySetException(string message) : base(message)
-        { }
-
-        public MilestoneAlreadySetException(string message, Exception innerException) : base(message, innerException)
         { }
     }
 }

--- a/src/Cake.GitHub/Issues/Exceptions/MilestoneNotFoundException.cs
+++ b/src/Cake.GitHub/Issues/Exceptions/MilestoneNotFoundException.cs
@@ -1,0 +1,8 @@
+﻿namespace Cake.GitHub
+{
+    internal class MilestoneNotFoundException : GitHubIssueException
+    {
+        public MilestoneNotFoundException(string message) : base(message)
+        { }
+    }
+}

--- a/src/Cake.GitHub/Issues/Exceptions/MilestoneNotFoundException.cs
+++ b/src/Cake.GitHub/Issues/Exceptions/MilestoneNotFoundException.cs
@@ -1,7 +1,14 @@
 ﻿namespace Cake.GitHub
 {
-    internal class MilestoneNotFoundException : GitHubIssueException
+    /// <summary>
+    /// Thrown when no matching Milestone was found.
+    /// </summary>
+    public sealed class MilestoneNotFoundException : GitHubIssueException
     {
+        /// <summary>
+        /// Initializes a new instance of <see cref="MilestoneNotFoundException"/> with the specified error message.
+        /// </summary>
+        /// <param name="message"></param>
         public MilestoneNotFoundException(string message) : base(message)
         { }
     }

--- a/src/Cake.GitHub/Issues/GitHubIssueUpdater.cs
+++ b/src/Cake.GitHub/Issues/GitHubIssueUpdater.cs
@@ -33,8 +33,9 @@ namespace Cake.GitHub
             if (String.IsNullOrWhiteSpace(milestoneTitle))
                 throw new ArgumentException("Value must not be null or whitespace", nameof(milestoneTitle));
 
-
             _cakeLog.Information($"Setting Milestone for Issue or Pull Request {number}");
+
+            LogSettings(owner, repository, number, milestoneTitle, settings);
 
             // Get issue or PR (every PR is also an issue and can be retrieved via the Issues API)
             var issue = await GetIssueAsync(owner, repository, number);
@@ -69,6 +70,18 @@ namespace Cake.GitHub
             }
         }
 
+        private void LogSettings(string owner, string repository, int number, string milestoneTitle, GitHubSetMilestoneSettings settings)
+        {
+            const int padding = -29;
+
+            _cakeLog.Debug("Setting GitHub Milestone with the following settings:");
+            _cakeLog.Debug($"\t{"Owner",padding}: '{owner}'");
+            _cakeLog.Debug($"\t{"Repository",padding}: '{repository}'");
+            _cakeLog.Debug($"\t{"Issue or Pull Requets Number",padding}: '{number}'");
+            _cakeLog.Debug($"\t{"MilestoneTitle",padding}: '{milestoneTitle}'");
+            _cakeLog.Debug($"\t{nameof(settings.Overwrite),padding}: '{settings.Overwrite}'");
+            _cakeLog.Debug($"\t{nameof(settings.CreateMilestone),padding}: '{settings.CreateMilestone}'");
+        }
 
         private async Task<Milestone> GetOrCreateMilestoneAsync(string owner, string repository, string milestoneTitle, GitHubSetMilestoneSettings settings)
         {
@@ -114,7 +127,5 @@ namespace Cake.GitHub
 
             return issue;
         }
-
-        // TODO: Log settings
     }
 }

--- a/src/Cake.GitHub/Issues/GitHubIssueUpdater.cs
+++ b/src/Cake.GitHub/Issues/GitHubIssueUpdater.cs
@@ -1,0 +1,98 @@
+﻿using Cake.Core.Diagnostics;
+using Octokit;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Cake.GitHub
+{
+    internal sealed class GitHubIssueUpdater
+    {
+        private readonly ICakeLog _cakeLog;
+        private readonly IGitHubClient _githubClient;
+
+
+        public GitHubIssueUpdater(ICakeLog cakeLog, IGitHubClient githubClient)
+        {
+            _cakeLog = cakeLog;
+            _githubClient = githubClient;
+        }
+
+
+        public async Task SetMilestoneAsync(string owner, string repository, int number, string milestoneTitle, GitHubSetMilestoneSettings settings)
+        {
+            if (String.IsNullOrWhiteSpace(owner))
+                throw new ArgumentException("Value must not be null or whitespace", nameof(owner));
+
+            if (String.IsNullOrWhiteSpace(repository))
+                throw new ArgumentException("Value must not be null or whitespace", nameof(repository));
+
+            if (number <= 0)
+                throw new ArgumentOutOfRangeException(nameof(number), "Value must not be negative");
+
+            if (String.IsNullOrWhiteSpace(milestoneTitle))
+                throw new ArgumentException("Value must not be null or whitespace", nameof(milestoneTitle));
+
+
+            _cakeLog.Information($"Setting Milestone for Issue or Pull Request {number}");
+
+            // Get issue or PR (every PR is also an issue and can be retrieved via the Issues API)
+            var issue = await GetIssueAsync(owner, repository, number);
+            var displayName = $"{(issue.PullRequest == null ? "Issue" : "Pull Request")} {number}";
+
+            // Get the milestone matching the specified title
+            var milestone = await GetMilestoneByTitleAsync(owner, repository, milestoneTitle);
+
+
+            // Update Issue or PR
+            if (issue.Milestone == null)
+            {
+                _cakeLog.Verbose($"{displayName} is not yet assigned to a Milestone, setting to Milestone {milestone.Number} '{milestone.Title}'");
+                await _githubClient.Issue.Update(owner, repository, number, new IssueUpdate() { Milestone = milestone.Number });
+            }
+            else if (issue.Milestone.Number == milestone.Number)
+            {
+                _cakeLog.Verbose($"{displayName} is already assigned to Milestone {milestone.Number} '{milestone.Title}'");
+                return;
+            }
+            else
+            {
+                throw new MilestoneAlreadySetException($"{displayName} is already assigned to Milestone {issue.Milestone.Number} '{issue.Milestone.Title}'");
+            }
+        }
+
+
+        private async Task<Milestone> GetMilestoneByTitleAsync(string owner, string repository, string milestoneTitle)
+        {
+            _cakeLog.Verbose($"Looking up Milestone with title '{milestoneTitle}'");
+
+            // Get all milestones and filter client-side since we only know the name and not the milestone number
+            var milestones = await _githubClient.Issue.Milestone.GetAllForRepository(owner, repository, new MilestoneRequest() { State = ItemStateFilter.All });
+            var milestone = milestones.SingleOrDefault(x => StringComparer.Ordinal.Equals(x.Title, milestoneTitle));
+
+            if (milestone == null)
+                throw new MilestoneNotFoundException($"No Milestone titled '{milestoneTitle}' was not found in repository {owner}/{repository}");
+
+            _cakeLog.Verbose($"Found Milestone {milestone.Number} with matching title");
+            return milestone;
+        }
+
+        private async Task<Issue> GetIssueAsync(string owner, string repository, int number)
+        {
+            _cakeLog.Verbose($"Retrieving Issue or Pull Request '{number}'");
+            Issue issue;
+            try
+            {
+                issue = await _githubClient.Issue.Get(owner, repository, number);
+            }
+            catch (NotFoundException ex)
+            {
+                throw new IssueNotFoundException($"Issue or Pull Request with number '{number}' was not found in repository {owner}/{repository}", ex);
+            }
+
+            return issue;
+        }
+
+        // TODO: Log settings
+    }
+}

--- a/src/Cake.GitHub/Issues/GitHubIssueUpdater.cs
+++ b/src/Cake.GitHub/Issues/GitHubIssueUpdater.cs
@@ -50,14 +50,22 @@ namespace Cake.GitHub
                 _cakeLog.Verbose($"{displayName} is not yet assigned to a Milestone, setting to Milestone {milestone.Number} '{milestone.Title}'");
                 await _githubClient.Issue.Update(owner, repository, number, new IssueUpdate() { Milestone = milestone.Number });
             }
-            else if (issue.Milestone.Number == milestone.Number)
-            {
-                _cakeLog.Verbose($"{displayName} is already assigned to Milestone {milestone.Number} '{milestone.Title}'");
-                return;
-            }
             else
             {
-                throw new MilestoneAlreadySetException($"{displayName} is already assigned to Milestone {issue.Milestone.Number} '{issue.Milestone.Title}'");
+                if (issue.Milestone.Number == milestone.Number)
+                {
+                    _cakeLog.Verbose($"{displayName} is already assigned to Milestone {milestone.Number} '{milestone.Title}'");
+                    return;
+                }
+                else if (settings.Overwrite)
+                {
+                    _cakeLog.Verbose($"Reassigning {displayName} Milestone {milestone.Number} '{milestone.Title}' because the 'Overwrite' setting was set to true.");
+                    await _githubClient.Issue.Update(owner, repository, number, new IssueUpdate() { Milestone = milestone.Number });
+                }
+                else
+                {
+                    throw new MilestoneAlreadySetException($"{displayName} is already assigned to Milestone {issue.Milestone.Number} '{issue.Milestone.Title}'");
+                }
             }
         }
 

--- a/src/Cake.GitHub/Issues/GitHubSetMilestoneSettings.cs
+++ b/src/Cake.GitHub/Issues/GitHubSetMilestoneSettings.cs
@@ -2,5 +2,9 @@
 {
     public class GitHubSetMilestoneSettings : GitHubSettingsBase
     {
+        /// <summary>
+        /// Gets or sets whether to replace a Issue's or Pull Request's milestone if it is already set
+        /// </summary>
+        public bool Overwrite { get; set; }
     }
 }

--- a/src/Cake.GitHub/Issues/GitHubSetMilestoneSettings.cs
+++ b/src/Cake.GitHub/Issues/GitHubSetMilestoneSettings.cs
@@ -6,5 +6,10 @@
         /// Gets or sets whether to replace a Issue's or Pull Request's milestone if it is already set
         /// </summary>
         public bool Overwrite { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether to create a new Milestone if the specified Milestone does not exist.
+        /// </summary>
+        public bool CreateMilestone { get; set; }
     }
 }

--- a/src/Cake.GitHub/Issues/GitHubSetMilestoneSettings.cs
+++ b/src/Cake.GitHub/Issues/GitHubSetMilestoneSettings.cs
@@ -1,0 +1,6 @@
+﻿namespace Cake.GitHub
+{
+    public class GitHubSetMilestoneSettings : GitHubSettingsBase
+    {
+    }
+}

--- a/src/Cake.GitHub/Issues/GitHubSetMilestoneSettings.cs
+++ b/src/Cake.GitHub/Issues/GitHubSetMilestoneSettings.cs
@@ -1,9 +1,12 @@
 ﻿namespace Cake.GitHub
 {
+    /// <summary>
+    /// Settings for setting an Issue's or Pull Request's Milestone.
+    /// </summary>
     public class GitHubSetMilestoneSettings : GitHubSettingsBase
     {
         /// <summary>
-        /// Gets or sets whether to replace a Issue's or Pull Request's milestone if it is already set
+        /// Gets or sets whether to replace a Issue's or Pull Request's milestone if it is already set.
         /// </summary>
         public bool Overwrite { get; set; }
 


### PR DESCRIPTION
Adds a new alias `GitHubSetMilestoneAsync` that can set the milestone for a GitHub Issue or Pull Request.

## Description

The `GitHubSetMilestoneAsync` alias is passed a Milestone title and an Issue or Pull Request number.
Using the Milestone's title, the Milestone is will be retrieved from GitHub and the Issue or Pull Request is updated with the milestone.

By default, calling the alias will fail if the issue is already assigned to a milestone or no matching milestone exists.
However, the optional `GitHubSetMilestoneSettings` allows "overwriting" a milestone and/or creating a new milestone if the milestone does not yet exist.

Note that most of the code talks about "Issues" rather then Pull Request since in the GitHub API, a Pull Request is just a special issue and all interactions happen through the Issues API.

## Motivation and Context

I implemented this because in my GitHub projects, I like to create a GitHub milestone for every version and assign all PRs to this milestone so I can easily find PRs that went into a specific version.

To avoid having to set the Milestone manually on every PR (or forget it), I'd like to assign the Milestone from the CI build, thus I found it would be useful to have this as Cake alias.

## How Has This Been Tested?

I added unit tests for this functionality and manually verified this works with a real-world repository on github.com

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] ~~I have read the **CONTRIBUTING** document~~ (there is none).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
