### PR TITLE
Update Octokit to version 13.0.1 to fix issue caused by GitHub Ids exceeding int.MaxValue

### DIFF
--- a/src/Cake.GitHub.Tests/Cake.GitHub.Tests.csproj
+++ b/src/Cake.GitHub.Tests/Cake.GitHub.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="NETStandard.Library" Version="2.0.1" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-	<PackageReference Include="Moq" Version="4.16.1" />
+	  <PackageReference Include="Moq" Version="4.16.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Cake.GitHub.Tests/Helpers/MoqExtensions.cs
+++ b/src/Cake.GitHub.Tests/Helpers/MoqExtensions.cs
@@ -22,7 +22,7 @@ namespace Cake.GitHub.Tests
 
         public static IReturnsResult<IIssuesClient> SetupUpdate(this Mock<IIssuesClient> mock) =>
             mock.Setup(x => x.Update(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<IssueUpdate>()))
-                .ReturnsAsync((string owner, string repo, int number, IssueUpdate update) => new TestIssue() { Number = number });
+                .ReturnsAsync((string owner, string repo, int number, IssueUpdate update) => new TestIssue(number));
 
         public static IReturnsResult<IMilestonesClient> ReturnsMilestonesAsync(this IReturns<IMilestonesClient, Task<IReadOnlyList<Milestone>>> mock, params Milestone[] milestones) =>
             mock.ReturnsAsync(milestones);

--- a/src/Cake.GitHub.Tests/Helpers/TestIssue.cs
+++ b/src/Cake.GitHub.Tests/Helpers/TestIssue.cs
@@ -1,19 +1,38 @@
 ﻿using Octokit;
+using System;
 
 namespace Cake.GitHub.Tests
 {
     internal class TestIssue : Issue
     {
-        public new int Number
-        {
-            get => base.Number;
-            set => base.Number = value;
-        }
-
-        public new Milestone Milestone
-        {
-            get => base.Milestone;
-            set => base.Milestone = value;
-        }
+        public TestIssue(int number = default, Milestone milestone = default)
+            : base(
+                url: default,
+                htmlUrl: default,
+                commentsUrl: default,
+                eventsUrl: default,
+                number: number,
+                state: default,
+                title: default,
+                body: default,
+                closedBy: default,
+                user: default,
+                labels: Array.Empty<Label>(),
+                assignee: default,
+                assignees: Array.Empty<User>(),
+                milestone: milestone,
+                comments: 0,
+                pullRequest: default,
+                closedAt: default,
+                createdAt: default,
+                updatedAt: default,
+                id: default,
+                nodeId: default,
+                locked: default,
+                repository: default,
+                reactions: default,
+                activeLockReason: default,
+                stateReason: default)
+        { }
     }
 }

--- a/src/Cake.GitHub.Tests/Helpers/TestMilestone.cs
+++ b/src/Cake.GitHub.Tests/Helpers/TestMilestone.cs
@@ -4,16 +4,23 @@ namespace Cake.GitHub.Tests
 {
     internal class TestMilestone : Milestone
     {
-        public new int Number
-        {
-            get => base.Number;
-            set => base.Number = value;
-        }
-
-        public new string Title
-        {
-            get => base.Title;
-            set => base.Title = value;
-        }
+        public TestMilestone(int number = default, string title = default)
+            : base(
+                url: default,
+                htmlUrl: default,
+                id: default,
+                number: number,
+                nodeId: default,
+                state: default,
+                title: title,
+                description: default,
+                creator: default,
+                openIssues: default,
+                closedIssues: default,
+                createdAt: default,
+                dueOn: default,
+                closedAt: default,
+                updatedAt: default)
+        { }
     }
 }

--- a/src/Cake.GitHub.Tests/Helpers/TestRelease.cs
+++ b/src/Cake.GitHub.Tests/Helpers/TestRelease.cs
@@ -1,25 +1,30 @@
 ﻿using Octokit;
+using System;
 
 namespace Cake.GitHub.Tests
 {
     internal class TestRelease : Release
     {
-        public new int Id
-        {
-            get => base.Id;
-            set => base.Id = value;
-        }
-
-        public new bool Draft
-        {
-            get => base.Draft;
-            set => base.Draft = value;
-        }
-
-        public new string TagName
-        {
-            get => base.TagName;
-            set => base.TagName = value;
-        }
+        public TestRelease(long id = default, string tagName = default, bool draft = default)
+            : base(
+                url: default,
+                htmlUrl: default,
+                assetsUrl: default,
+                uploadUrl: default,
+                id: id,
+                nodeId: default,
+                tagName: tagName,
+                targetCommitish: default,
+                name: default,
+                body: default,
+                draft: draft,
+                prerelease: default,
+                createdAt: default,
+                publishedAt: default,
+                author: default,
+                tarballUrl: default,
+                zipballUrl: default,
+                assets: Array.Empty<ReleaseAsset>())
+        { }
     }
 }

--- a/src/Cake.GitHub.Tests/Helpers/TestReleaseAsset.cs
+++ b/src/Cake.GitHub.Tests/Helpers/TestReleaseAsset.cs
@@ -4,10 +4,21 @@ namespace Cake.GitHub.Tests
 {
     public class TestReleaseAsset : ReleaseAsset
     {
-        public new string Name
-        {
-            get => base.Name;
-            set => base.Name = value;
-        }
+        public TestReleaseAsset(string name)
+            : base(
+                url: default,
+                id: default,
+                nodeId: default,
+                name: name,
+                label: default,
+                state: default,
+                contentType: default,
+                size: default,
+                downloadCount: default,
+                createdAt: default,
+                updatedAt: default,
+                browserDownloadUrl: default,
+                uploader: default)
+        { }
     }
 }

--- a/src/Cake.GitHub.Tests/Issues/GitHubIssueUpdaterTests.cs
+++ b/src/Cake.GitHub.Tests/Issues/GitHubIssueUpdaterTests.cs
@@ -96,13 +96,13 @@ namespace Cake.GitHub.Tests
 
             _clientMock.Issues.Mock
                 .Setup(x => x.Get(owner, repo, number))
-                .ReturnsAsync(new TestIssue() { Number = number });
+                .ReturnsAsync(new TestIssue(number));
 
             _clientMock.Issues.Milestone
                 .Setup(x => x.GetAllForRepository(owner, repo, It.IsAny<MilestoneRequest>()))
                 .ReturnsMilestonesAsync(
-                    new TestMilestone() { Number = 1, Title = "Milestone 1" },
-                    new TestMilestone() { Number = 1, Title = "Milestone 2" }
+                    new TestMilestone(number: 1, title: "Milestone 1"),
+                    new TestMilestone(number: 1, title: "Milestone 2")
                 );
 
             // ACT 
@@ -131,14 +131,14 @@ namespace Cake.GitHub.Tests
 
             _clientMock.Issues.Mock
                 .Setup(x => x.Get(owner, repo, number))
-                .ReturnsAsync(new TestIssue() { Number = number });
+                .ReturnsAsync(new TestIssue(number));
 
             _clientMock.Issues.Mock.SetupUpdate();
 
             _clientMock.Issues.Milestone
                 .Setup(x => x.GetAllForRepository(owner, repo, It.IsAny<MilestoneRequest>()))
                 .ReturnsMilestonesAsync(
-                    new TestMilestone() { Number = 1, Title = existingMilestoneTitle }
+                    new TestMilestone(number: number, title: existingMilestoneTitle)
                 );
 
             // ACT 
@@ -168,12 +168,12 @@ namespace Cake.GitHub.Tests
 
             _clientMock.Issues.Mock
                 .Setup(x => x.Get(owner, repo, issueNumber))
-                .ReturnsAsync(new TestIssue() { Number = issueNumber });
+                .ReturnsAsync(new TestIssue(issueNumber));
 
             _clientMock.Issues.Milestone
                 .Setup(x => x.GetAllForRepository(owner, repo, It.IsAny<MilestoneRequest>()))
                 .ReturnsMilestonesAsync(
-                    new TestMilestone() { Number = milestoneNumber, Title = milestoneTitle }
+                    new TestMilestone(number: milestoneNumber, title: milestoneTitle)
                 );
 
             _clientMock.Issues.Mock.SetupUpdate();
@@ -197,18 +197,13 @@ namespace Cake.GitHub.Tests
 
             _clientMock.Issues.Mock
                 .Setup(x => x.Get(owner, repo, issueNumber))
-                .ReturnsAsync(
-                    new TestIssue()
-                    {
-                        Number = issueNumber,
-                        Milestone = new TestMilestone() { Number = 1, Title = "Milestone 1" }
-                    });
+                .ReturnsAsync(new TestIssue(number: issueNumber, milestone: new TestMilestone(number: 1, title: "Milestone 1")));
 
             _clientMock.Issues.Milestone
                 .Setup(x => x.GetAllForRepository(owner, repo, It.IsAny<MilestoneRequest>()))
                 .ReturnsMilestonesAsync(
-                    new TestMilestone() { Number = 1, Title = "Milestone 1" },
-                    new TestMilestone() { Number = 2, Title = "Milestone 2" }
+                    new TestMilestone(number: 1, title: "Milestone 1"),
+                    new TestMilestone(number: 2, title: "Milestone 2")
                 );
 
             _clientMock.Issues.Mock.SetupUpdate();
@@ -234,18 +229,11 @@ namespace Cake.GitHub.Tests
 
             _clientMock.Issues.Mock
                 .Setup(x => x.Get(owner, repo, issueNumber))
-                .ReturnsAsync(
-                    new TestIssue()
-                    {
-                        Number = issueNumber,
-                        Milestone = new TestMilestone() { Number = milestoneNumber }
-                    });
+                .ReturnsAsync(new TestIssue(number: issueNumber, milestone: new TestMilestone(milestoneNumber)));
 
             _clientMock.Issues.Milestone
                 .Setup(x => x.GetAllForRepository(owner, repo, It.IsAny<MilestoneRequest>()))
-                .ReturnsMilestonesAsync(
-                    new TestMilestone() { Number = milestoneNumber, Title = milestoneTitle }
-                );
+                .ReturnsMilestonesAsync(new TestMilestone(number: milestoneNumber, title: milestoneTitle));
 
             // ACT 
             await sut.SetMilestoneAsync(owner: owner, repository: repo, number: issueNumber, milestoneTitle: milestoneTitle, new GitHubSetMilestoneSettings());
@@ -265,18 +253,13 @@ namespace Cake.GitHub.Tests
 
             _clientMock.Issues.Mock
                 .Setup(x => x.Get(owner, repo, issueNumber))
-                .ReturnsAsync(
-                    new TestIssue()
-                    {
-                        Number = issueNumber,
-                        Milestone = new TestMilestone() { Number = 1, Title = "Milestone 1" }
-                    });
+                .ReturnsAsync(new TestIssue(number: issueNumber, milestone: new TestMilestone(number: 1, title: "Milestone 1")));
 
             _clientMock.Issues.Milestone
                 .Setup(x => x.GetAllForRepository(owner, repo, It.IsAny<MilestoneRequest>()))
                 .ReturnsMilestonesAsync(
-                    new TestMilestone() { Number = 1, Title = "Milestone 1" },
-                    new TestMilestone() { Number = 2, Title = "Milestone 2" }
+                    new TestMilestone(number: 1, title: "Milestone 1"),
+                    new TestMilestone(number: 2, title: "Milestone 2")
                 );
 
             _clientMock.Issues.Mock.SetupUpdate();
@@ -305,7 +288,7 @@ namespace Cake.GitHub.Tests
 
             _clientMock.Issues.Mock
                 .Setup(x => x.Get(owner, repo, issueNumber))
-                .ReturnsAsync(new TestIssue() { Number = issueNumber });
+                .ReturnsAsync(new TestIssue(issueNumber));
 
             _clientMock.Issues.Milestone
                 .Setup(x => x.GetAllForRepository(owner, repo, It.IsAny<MilestoneRequest>()))
@@ -313,7 +296,7 @@ namespace Cake.GitHub.Tests
 
             _clientMock.Issues.Milestone
                 .Setup(x => x.Create(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<NewMilestone>()))
-                .ReturnsAsync((string repo, string owner, NewMilestone newMilestone) => new TestMilestone() { Number = 2, Title = newMilestone.Title });
+                .ReturnsAsync((string repo, string owner, NewMilestone newMilestone) => new TestMilestone(number: 2, title: newMilestone.Title));
 
             _clientMock.Issues.Mock.SetupUpdate();
 

--- a/src/Cake.GitHub/Cake.GitHub.csproj
+++ b/src/Cake.GitHub/Cake.GitHub.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <VersionPrefix>0.1.0</VersionPrefix>
-    <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Cake.GitHub</AssemblyName>
     <PackageId>Cake.GitHub</PackageId>
@@ -29,8 +29,8 @@
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp" Version="4.4.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-	<PackageReference Include="Octokit" Version="0.50.0" />
-	<PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="Octokit" Version="13.0.1" />
+	  <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
 </Project>

--- a/src/Cake.GitHub/Releases/GitHubRelease.cs
+++ b/src/Cake.GitHub/Releases/GitHubRelease.cs
@@ -1,7 +1,7 @@
-﻿using System;
+﻿using Octokit;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using Octokit;
 
 namespace Cake.GitHub
 {
@@ -15,7 +15,7 @@ namespace Cake.GitHub
         /// <summary>
         /// Gets the release's id
         /// </summary>
-        public int Id { get; }
+        public long Id { get; }
 
         /// <summary>
         /// Gets the url of the release in the GitHub web interface.
@@ -71,7 +71,7 @@ namespace Cake.GitHub
         /// <summary>
         /// Initializes a new instance of <see cref="GitHubRelease"/>
         /// </summary>
-        public GitHubRelease(int id, string htmlUrl, string tagName, string targetCommitish, string name, string body, bool draft, bool prerelease, DateTime createdAt, DateTime? publishedAt)
+        public GitHubRelease(long id, string htmlUrl, string tagName, string targetCommitish, string name, string body, bool draft, bool prerelease, DateTime createdAt, DateTime? publishedAt)
         {
             Id = id;
             HtmlUrl = htmlUrl;
@@ -92,7 +92,7 @@ namespace Cake.GitHub
         /// Converts a Octokit <see cref="Release" /> to a <see cref="GitHubRelease"/>
         /// </summary>
         internal static GitHubRelease FromRelease(Release release)
-        {            
+        {
             var githubRelease = new GitHubRelease(
                 id: release.Id,
                 htmlUrl: release.HtmlUrl,


### PR DESCRIPTION
## Description

The internal ids on GitHub now exceed Int.MaxValue causing issues e.g. in the GitHubSetMilestoneAsync alias (specifically in the call to IGitHubClient.Issue.Get).
This has been fixed in the latest version of Octokit.

Updating Octokit to the latest version required some additional changes since the previously referenced version of Octokit was from 2021:

- Cake.GitHub is no longer build for .NET Framework but only for netstandard2.0. This should not be a problem as Cake no longer supports running on .NET Framework either (since Cake 2.0)
- The GitHubRelease.Id property is now of type long instead of int
- The test model classes (e.g. TestIssue) had to be adapted since values on the underlying Octokit types can no longer be set


## Motivation and Context

- Before this change, Cake.GitHub was not usable for issues or Pull Requests that were created after GitHub's Ids exceeded int.MaxValue

## How Has This Been Tested?

- All tests in this repo still pass or have been adapted (locally)
- I manually tested these changed in one of my projects where Cake.GitLab is used


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
  - The type of one property in he public API of Cake.GitLab has changed (GitHubRelease.Id is now a long value)
  - Cake.GitLab can no longer run on Cake versions before 2.0 since this removes .NET Framework support

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
